### PR TITLE
Changing module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/free5gc/logger_util
+module github.com/omec-project/logger_util
 
 go 1.14
 


### PR DESCRIPTION
Referring to opec-project repositories and  module name should have omec-project